### PR TITLE
Support TTL and class reordering

### DIFF
--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -279,7 +279,10 @@ grammar Zonefile
   end
 
   rule sshfp_record
-    host space ms_age ttl klass "SSHFP" space alg:integer space fptype:integer space fp:fingerprint {
+    (
+     host space ms_age ttl klass "SSHFP" space alg:integer space fptype:integer space fp:fingerprint / 
+     host space ms_age klass ttl "SSHFP" space alg:integer space fptype:integer space fp:fingerprint 
+    ) {
       def to_s
         "#{host} #{ttl} #{klass} SSHFP #{alg} #{fptype} #{fp}"
       end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -89,7 +89,10 @@ grammar Zonefile
   end
 
   rule a_record
-    host space ms_age ttl klass "A" space ip_address {
+    (
+     host space ms_age ttl klass "A" space ip_address /
+     host space ms_age klass ttl "A" space ip_address
+    ) {
       def to_s
         "#{host} #{ms_age} #{ttl} #{klass} A #{ip_address}"
       end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -561,7 +561,7 @@ grammar Zonefile
   end
 
   rule unquoted_string
-    [a-zA-Z0-9=_\.]+ {
+    [a-zA-Z0-9=_\.\-]+ {
       def to_s
         text_value
       end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -294,7 +294,10 @@ grammar Zonefile
   end
 
   rule txt_record
-    host space ms_age ttl klass "TXT" space data:ms_txt_data {
+    (
+     host space ms_age ttl klass "TXT" space data:ms_txt_data /
+     host space ms_age klass ttl "TXT" space data:ms_txt_data
+    ) {
       def to_s
         "#{host} #{ttl} #{klass} TXT #{data}"
       end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -264,7 +264,10 @@ grammar Zonefile
   end
 
   rule spf_record
-    host space ms_age ttl klass "SPF" space data:txt_data {
+    (
+     host space ms_age ttl klass "SPF" space data:txt_data /
+     host space ms_age klass ttl "SPF" space data:txt_data 
+    ) {
       def to_s
         "#{host} #{ttl} #{klass} SPF #{data}"
       end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -205,7 +205,10 @@ grammar Zonefile
   end
 
   rule ns_record
-    host space ms_age ttl klass "NS" space nameserver:host {
+    (
+     host space ms_age ttl klass "NS" space nameserver:host /
+     host space ms_age klass ttl "NS" space nameserver:host
+    ) {
       def to_s
         "#{host} #{ttl} #{klass} NS #{nameserver}"
       end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -190,7 +190,10 @@ grammar Zonefile
   end
   
   rule naptr_record
-    host space ms_age ttl klass "NAPTR" space data {
+    (
+     host space ms_age ttl klass "NAPTR" space data /
+     host space ms_age klass ttl "NAPTR" space data
+    ) {
       def to_s
         "#{host} #{ttl} #{klass} NAPTR #{data}"
       end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -175,7 +175,10 @@ grammar Zonefile
   end
 
   rule mx_record
-    host space ttl klass "MX" space priority:integer space exchanger:host {
+    (
+     host space ttl klass "MX" space priority:integer space exchanger:host /
+     host space klass ttl "MX" space priority:integer space exchanger:host
+    ) {
       def to_s
         "#{host} #{ttl} #{klass} MX #{priority} #{exchanger}"
       end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -43,7 +43,10 @@ grammar Zonefile
   end
 
   rule soa
-    origin space ttl klass "SOA" space ns space rp space "("?  multiline_comment* space_or_break* serial multiline_comment* space_or_break refresh multiline_comment* space_or_break reretry multiline_comment* space_or_break expiry multiline_comment* space_or_break nxttl multiline_comment* space_or_break* ")"? {
+    (
+     origin space ttl klass "SOA" space ns space rp space "("?  multiline_comment* space_or_break* serial multiline_comment* space_or_break refresh multiline_comment* space_or_break reretry multiline_comment* space_or_break expiry multiline_comment* space_or_break nxttl multiline_comment* space_or_break* ")"? /
+     origin space klass ttl "SOA" space ns space rp space "("?  multiline_comment* space_or_break* serial multiline_comment* space_or_break refresh multiline_comment* space_or_break reretry multiline_comment* space_or_break expiry multiline_comment* space_or_break nxttl multiline_comment* space_or_break* ")"?
+    ) {
       def to_s
         "#{origin} #{ttl} #{klass} SOA #{ns} #{rp} (#{serial} #{refresh} #{reretry} #{expiry} #{nxttl})"
       end
@@ -235,7 +238,10 @@ grammar Zonefile
   end
 
   rule soa_record
-    origin space ms_age ttl klass "SOA" space ns space rp space data {
+    (
+     origin space ms_age ttl klass "SOA" space ns space rp space data /
+     origin space ms_age klass ttl "SOA" space ns space rp space data
+    ) {
       def to_s
         "#{origin} #{ttl} #{klass} SOA #{ns} #{rp} (#{space})"
       end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -220,7 +220,10 @@ grammar Zonefile
   end
 
   rule ptr_record
-    host space ms_age ttl klass "PTR" space target:host {
+    (
+     host space ms_age ttl klass "PTR" space target:host /
+     host space ms_age klass ttl "PTR" space target:host
+    ) {
       def to_s
         "#{host} #{ttl} #{klass} PTR #{target}"
       end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -561,7 +561,7 @@ grammar Zonefile
   end
 
   rule unquoted_string
-    [a-zA-Z0-9=_\.\-]+ {
+    '[a-zA-Z0-9=_\.\-\@\:]+'r {
       def to_s
         text_value
       end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -112,7 +112,10 @@ grammar Zonefile
   end
   
   rule aaaa_record
-    host space ms_age ttl klass "AAAA" space ip_address:ip6_address {
+    (
+     host space ms_age ttl klass "AAAA" space ip_address:ip6_address /
+     host space ms_age klass ttl "AAAA" space ip_address:ip6_address
+    ) {
       def to_s
         "#{host} #{ttl} #{klass} AAAA #{ip_address}"
       end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -561,7 +561,7 @@ grammar Zonefile
   end
 
   rule unquoted_string
-    [a-zA-Z0-9=_]+ {
+    [a-zA-Z0-9=_\.]+ {
       def to_s
         text_value
       end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -136,7 +136,8 @@ grammar Zonefile
 
   rule caa_record
     (
-      host space ms_age ttl klass "CAA" space flags:integer space tag:unquoted_string space value:caa_value
+      host space ms_age ttl klass "CAA" space flags:integer space tag:unquoted_string space value:caa_value /
+      host space ms_age klass ttl "CAA" space flags:integer space tag:unquoted_string space value:caa_value
     ) {
       def to_s
         "#{host} #{ttl} #{klass} CAA #{flags} #{tag} #{value}"

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -105,6 +105,8 @@ RSpec.describe "DNS::Zonefile" do
         with-underscore TXT abc_123
         with-dot  TXT a.b
         with-dash TXT a-b
+        with-at TXT a@b
+        with-colon TXT a:b
 
         with-ttl 60 TXT "example"
         with-class IN TXT "example"
@@ -190,7 +192,7 @@ RSpec.describe "DNS::Zonefile" do
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(94)
+      expect(zone.rr.size).to eq(96)
     end
 
     it "should build the correct NS records" do
@@ -415,7 +417,7 @@ RSpec.describe "DNS::Zonefile" do
     it "should build the correct TXT records" do
       zone = DNS::Zonefile.load(@zonefile)
       txt_records = zone.records_of DNS::Zonefile::TXT
-      expect(txt_records.size).to eq(14)
+      expect(txt_records.size).to eq(16)
 
       expect(txt_records.detect { |r|
         r.host == "_domainkey.example.com." && r.data == '"v=DKIM1\;g=*\;k=rsa\; p=4tkw1bbkfa0ahfjgnbewr2ttkvahvfmfizowl9s4g0h28io76ndow25snl9iumpcv0jwxr2k"'

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "DNS::Zonefile" do
         ; Let's start the resource records.
         example.com.  NS    ns                    ; ns.example.com is the nameserver for example.com
         example.com.  NS    ns.somewhere.com.     ; ns.somewhere.com is a backup nameserver for example.com
+
         example.com.  A     10.0.0.1              ; ip address for "example.com". next line has spaces after the IP, but no actual comment.
         @             A     10.0.0.11
                       A     10.0.0.12             ; tertiary ip for "example.com"
@@ -47,6 +48,7 @@ RSpec.describe "DNS::Zonefile" do
         with-ttl  60     A   10.0.0.5             ; with a specified TTL
         ttl-class 60 IN  A   10.0.0.6             ; with TTL and class type
         class-ttl IN 60 A 10.0.0.7                ; with class type and TTL
+
         www           CNAME ns                    ; "www.example.com" is an alias for "ns.example.com"
         wwwtest       CNAME www                   ; "wwwtest.example.com" is another alias for "www.example.com"
         www2          CNAME ns.example.com.       ; yet another alias, with FQDN target
@@ -59,6 +61,10 @@ RSpec.describe "DNS::Zonefile" do
         @             AAAA  2001:db8:a::1         ; IPv6, lowercase
         ns            AAAA  2001:DB8:B::1         ; IPv6, uppercase
         mail          AAAA  2001:db8:c::10.0.0.4  ; IPv6, with trailing IPv4-type address
+        with-class  IN    AAAA 2001:db8:d::1      ; IPv6, with class
+        with-ttl    60    AAAA 2001:db8:d::2      ; IPv6, with TTL
+        ttl-class   60 IN AAAA 2001:db8:d::3      ; IPv6, with TTL and class type
+        class-ttl   IN 60 AAAA 2001:db8:d::4      ; IPv6, with class type and TTL
         
         sip           NAPTR 100 10 "U" "E2U+sip" "!^.*$!sip:cs@example.com!i" .   ; NAPTR record
         sip2          NAPTR 100 10 "" "" "/urn:cid:.+@([^\\.]+\\.)(.*)$/\\2/i" .     ; another one
@@ -150,7 +156,7 @@ RSpec.describe "DNS::Zonefile" do
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(56)
+      expect(zone.rr.size).to eq(60)
     end
 
     it "should build the correct NS records" do
@@ -302,7 +308,7 @@ RSpec.describe "DNS::Zonefile" do
     it "should build the correct AAAA records" do
       zone = DNS::Zonefile.load(@zonefile)
       aaaa_records = zone.records_of DNS::Zonefile::AAAA
-      expect(aaaa_records.length).to eq(4)
+      expect(aaaa_records.length).to eq(8)
 
       expect(aaaa_records.detect { |a|
         a.host == "example.com." && a.address == "2001:db8:a::1"

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -114,7 +114,11 @@ RSpec.describe "DNS::Zonefile" do
         _ldap._tcp.pupy._sites.dc._msdcs [AGE:3636525]	600	SRV	0 100 389	host01.ad
         P229392922               [AGE:3636449]	172800	CNAME	printer01.ad
         
-        @             SPF   "v=spf1 a a:other.domain.com ~all"
+        @ SPF   "v=spf1 a a:other.domain.com ~all" ; SPF (deprecated)
+        with-class    IN  SPF   "v=spf1 a a:other.domain.com ~all" ; SPF with class
+        with-ttl  60      SPF   "v=spf1 a a:other.domain.com ~all" ; SPF with ttl
+        ttl-class 60  IN  SPF   "v=spf1 a a:other.domain.com ~all" ; SPF with ttl and class
+        class-ttl IN  60  SPF   "v=spf1 a a:other.domain.com ~all" ; SPF with class and ttl
         
         44 PTR @
         45 IN    PTR   @
@@ -175,7 +179,7 @@ RSpec.describe "DNS::Zonefile" do
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(80)
+      expect(zone.rr.size).to eq(84)
     end
 
     it "should build the correct NS records" do
@@ -434,7 +438,7 @@ RSpec.describe "DNS::Zonefile" do
     it "should build the correct SPF records" do
       zone = DNS::Zonefile.load(@zonefile)
       spf_records = zone.records_of DNS::Zonefile::SPF
-      expect(spf_records.length).to eq(1)
+      expect(spf_records.length).to eq(5)
 
       expect(spf_records.detect { |r|
         r.host == "example.com." && r.data == '"v=spf1 a a:other.domain.com ~all"' && r.ttl == 86400

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -83,7 +83,11 @@ RSpec.describe "DNS::Zonefile" do
         
         _xmpp-server._tcp   SRV   5 0 5269 xmpp-server.l.google.com.  ; SRV record
         
-        sshfp         SSHFP 4 2 9e:1a:5e:27:16:4d:2a:13:90:2c:64:41:bd:25:fd:35 ; SSHFP record
+        sshfp SSHFP 4 2 9e:1a:5e:27:16:4d:2a:13:90:2c:64:41:bd:25:fd:35 ; SSHFP record
+        with-ttl 60 SSHFP 4 2 9e:1a:5e:27:16:4d:2a:13:90:2c:64:41:bd:25:fd:35 ; SSHFP record with class
+        with-class IN SSHFP 4 2 9e:1a:5e:27:16:4d:2a:13:90:2c:64:41:bd:25:fd:35 ; SSHFP record with ttl
+        ttl-class 60 IN SSHFP 4 2 9e:1a:5e:27:16:4d:2a:13:90:2c:64:41:bd:25:fd:35 ; SSHFP record with ttl and class
+        class-ttl IN 60 SSHFP 4 2 9e:1a:5e:27:16:4d:2a:13:90:2c:64:41:bd:25:fd:35 ; SSHFP record with class and ttl
         
         ; TXT record, with embedded semicolons
         _domainkey    TXT   "v=DKIM1\\;g=*\\;k=rsa\\; p=4tkw1bbkfa0ahfjgnbewr2ttkvahvfmfizowl9s4g0h28io76ndow25snl9iumpcv0jwxr2k"
@@ -179,7 +183,7 @@ RSpec.describe "DNS::Zonefile" do
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(84)
+      expect(zone.rr.size).to eq(88)
     end
 
     it "should build the correct NS records" do
@@ -394,7 +398,7 @@ RSpec.describe "DNS::Zonefile" do
     it "should build the correct SSHFP records" do
       zone = DNS::Zonefile.load(@zonefile)
       sshfp_records = zone.records_of DNS::Zonefile::SSHFP
-      expect(sshfp_records.size).to eq(1)
+      expect(sshfp_records.size).to eq(5)
 
       expect(sshfp_records.detect { |r|
         r.host == "sshfp.example.com." && r.alg == 4 && r.fptype = 2 && r.fp == "9e:1a:5e:27:16:4d:2a:13:90:2c:64:41:bd:25:fd:35"

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -72,6 +72,10 @@ RSpec.describe "DNS::Zonefile" do
         
         sip           NAPTR 100 10 "U" "E2U+sip" "!^.*$!sip:cs@example.com!i" .   ; NAPTR record
         sip2          NAPTR 100 10 "" "" "/urn:cid:.+@([^\\.]+\\.)(.*)$/\\2/i" .     ; another one
+        with-class IN   NAPTR 100 10 "U" "E2U+sip" "!^.*$!sip:cs@example.com!i" .   ; with class
+        with-ttl 60     NAPTR 100 10 "U" "E2U+sip" "!^.*$!sip:cs@example.com!i" .   ; with ttl
+        ttl-class 60 IN NAPTR 100 10 "U" "E2U+sip" "!^.*$!sip:cs@example.com!i" .   ; with ttl and class
+        class-ttl IN 60 NAPTR 100 10 "U" "E2U+sip" "!^.*$!sip:cs@example.com!i" .   ; with class and ttl
         
         _xmpp-server._tcp   SRV   5 0 5269 xmpp-server.l.google.com.  ; SRV record
         
@@ -164,7 +168,7 @@ RSpec.describe "DNS::Zonefile" do
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(68)
+      expect(zone.rr.size).to eq(72)
     end
 
     it "should build the correct NS records" do
@@ -338,7 +342,7 @@ RSpec.describe "DNS::Zonefile" do
     it "should build the correct NAPTR records" do
       zone = DNS::Zonefile.load(@zonefile)
       naptr_records = zone.records_of DNS::Zonefile::NAPTR
-      expect(naptr_records.length).to eq(2)
+      expect(naptr_records.length).to eq(6)
 
       expect(naptr_records.detect { |r|
         r.host == "sip.example.com." && r.data == '100 10 "U" "E2U+sip" "!^.*$!sip:cs@example.com!i" .'

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -468,6 +468,53 @@ RSpec.describe "DNS::Zonefile" do
     end
   end
 
+  describe "parsing SOA with and without TTL and class" do
+    it "should parse the SOA record correctly without TTL and class" do
+      @zonefile = <<~ZONE
+        example.com.	SOA ns0.example.com. hostmaster.example.com. 2006010558 43200 3600 1209600 180
+        example.com.	SOA ns0.example.com. hostmaster.example.com. 2006010558 43200 3600 1209600 180
+      ZONE
+      zone = DNS::Zonefile.load(@zonefile)
+      soa = zone.soa
+      expect(soa.klass).to eql("IN")
+      expect(soa.ttl).to eql(nil)
+    end
+    it "should parse the SOA record correctly with TTL and class" do
+      @zonefile = <<~ZONE
+        example.com.	3600 IN SOA ns0.example.com. hostmaster.example.com. 2006010558 43200 3600 1209600 180
+        example.com.	3600 IN SOA ns0.example.com. hostmaster.example.com. 2006010558 43200 3600 1209600 180
+      ZONE
+      zone = DNS::Zonefile.load(@zonefile)
+      soa = zone.soa
+      expect(soa.klass).to eql("IN")
+      expect(soa.ttl).to eql(3600)
+    end
+    it "should parse the SOA record correctly with class and TTL" do
+      @zonefile = <<~ZONE
+        example.com.	IN 3600 SOA ns0.example.com. hostmaster.example.com. 2006010558 43200 3600 1209600 180
+        example.com.	IN 3600 SOA ns0.example.com. hostmaster.example.com. 2006010558 43200 3600 1209600 180
+      ZONE
+      zone = DNS::Zonefile.load(@zonefile)
+      soa = zone.soa
+      expect(soa.klass).to eql("IN")
+      expect(soa.ttl).to eql(3600)
+    end
+    it "should parse the SOA record correctly with class" do
+      @zonefile = "example.com.	IN SOA ns0.example.com. hostmaster.example.com. 2006010558 43200 3600 1209600 180"
+      zone = DNS::Zonefile.load(@zonefile)
+      soa = zone.soa
+      expect(soa.klass).to eql("IN")
+      expect(soa.ttl).to eql(nil)
+    end
+    it "should parse the SOA record correctly with TTL" do
+      @zonefile = "example.com.	3600 SOA ns0.example.com. hostmaster.example.com. 2006010558 43200 3600 1209600 180"
+      zone = DNS::Zonefile.load(@zonefile)
+      soa = zone.soa
+      expect(soa.klass).to eql("IN")
+      expect(soa.ttl).to eql(3600)
+    end
+  end
+
   describe "parsing an SOA without parens" do
     before(:each) do
       @zonefile = <<~ZONE

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -116,8 +116,11 @@ RSpec.describe "DNS::Zonefile" do
         
         @             SPF   "v=spf1 a a:other.domain.com ~all"
         
-        45        IN   PTR   @
-        
+        44 PTR @
+        45 IN    PTR   @
+        46 60    PTR @
+        47 60 IN PTR @
+        48 IN 60 PTR @
         
         eam 900 IN SRV 5 0 5269 www
         eam IN 900 SRV 5 0 5269 www
@@ -172,7 +175,7 @@ RSpec.describe "DNS::Zonefile" do
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(76)
+      expect(zone.rr.size).to eq(80)
     end
 
     it "should build the correct NS records" do
@@ -441,10 +444,13 @@ RSpec.describe "DNS::Zonefile" do
     it "should build the correct PTR records" do
       zone = DNS::Zonefile.load(@zonefile)
       ptr_records = zone.records_of DNS::Zonefile::PTR
-      expect(ptr_records.length).to eq(1)
+      expect(ptr_records.length).to eq(5)
 
       expect(ptr_records.detect { |r|
+        r.host == "44.example.com." && r.target == "example.com." && r.ttl == 86400
         r.host == "45.example.com." && r.target == "example.com." && r.ttl == 86400
+        r.host == "46.example.com." && r.target == "example.com." && r.ttl == 60
+        r.host == "47.example.com." && r.target == "example.com." && r.ttl == 60
       }).to_not be_nil
     end
   end

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -103,6 +103,11 @@ RSpec.describe "DNS::Zonefile" do
         with LF and CRLF line endings"
         
         with-underscore TXT abc_123
+
+        with-ttl 60 TXT "example"
+        with-class IN TXT "example"
+        ttl-class 60 IN TXT "example"
+        class-ttl IN 60 TXT "example"
         
         @             CAA   0 issue "letsencrypt.org"
         issuewild     CAA   0 issuewild "comodoca.com"
@@ -183,7 +188,7 @@ RSpec.describe "DNS::Zonefile" do
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(88)
+      expect(zone.rr.size).to eq(92)
     end
 
     it "should build the correct NS records" do
@@ -408,7 +413,7 @@ RSpec.describe "DNS::Zonefile" do
     it "should build the correct TXT records" do
       zone = DNS::Zonefile.load(@zonefile)
       txt_records = zone.records_of DNS::Zonefile::TXT
-      expect(txt_records.size).to eq(8)
+      expect(txt_records.size).to eq(12)
 
       expect(txt_records.detect { |r|
         r.host == "_domainkey.example.com." && r.data == '"v=DKIM1\;g=*\;k=rsa\; p=4tkw1bbkfa0ahfjgnbewr2ttkvahvfmfizowl9s4g0h28io76ndow25snl9iumpcv0jwxr2k"'

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe "DNS::Zonefile" do
         with-class   IN  A   10.0.0.3             ; record that includes the class type of IN
         with-ttl  60     A   10.0.0.5             ; with a specified TTL
         ttl-class 60 IN  A   10.0.0.6             ; with TTL and class type
+        class-ttl IN 60 A 10.0.0.7                ; with class type and TTL
         www           CNAME ns                    ; "www.example.com" is an alias for "ns.example.com"
         wwwtest       CNAME www                   ; "wwwtest.example.com" is another alias for "www.example.com"
         www2          CNAME ns.example.com.       ; yet another alias, with FQDN target
@@ -149,7 +150,7 @@ RSpec.describe "DNS::Zonefile" do
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(55)
+      expect(zone.rr.size).to eq(56)
     end
 
     it "should build the correct NS records" do
@@ -169,7 +170,7 @@ RSpec.describe "DNS::Zonefile" do
     it "should build the correct A records" do
       zone = DNS::Zonefile.load(@zonefile)
       a_records = zone.records_of DNS::Zonefile::A
-      expect(a_records.size).to eq(13)
+      expect(a_records.size).to eq(14)
 
       expect(a_records.detect { |a|
         a.host == "example.com." && a.address == "10.0.0.1"

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe "DNS::Zonefile" do
         with LF and CRLF line endings"
         
         with-underscore TXT abc_123
+        with-dot  TXT a.b
 
         with-ttl 60 TXT "example"
         with-class IN TXT "example"
@@ -188,7 +189,7 @@ RSpec.describe "DNS::Zonefile" do
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(92)
+      expect(zone.rr.size).to eq(93)
     end
 
     it "should build the correct NS records" do
@@ -413,7 +414,7 @@ RSpec.describe "DNS::Zonefile" do
     it "should build the correct TXT records" do
       zone = DNS::Zonefile.load(@zonefile)
       txt_records = zone.records_of DNS::Zonefile::TXT
-      expect(txt_records.size).to eq(12)
+      expect(txt_records.size).to eq(13)
 
       expect(txt_records.detect { |r|
         r.host == "_domainkey.example.com." && r.data == '"v=DKIM1\;g=*\;k=rsa\; p=4tkw1bbkfa0ahfjgnbewr2ttkvahvfmfizowl9s4g0h28io76ndow25snl9iumpcv0jwxr2k"'

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -57,6 +57,10 @@ RSpec.describe "DNS::Zonefile" do
         example.com.  MX    10 mail.example.com.  ; mail.example.com is the mailserver for example.com
         @             MX    20 mail2.example.com. ; Similar to above line, but using "@" to say "use $ORIGIN"
         @             MX    50 mail3              ; Similar to above line, but using a host within this domain
+        with-class  IN    MX  10 mail.example.com.; MX with class
+        with-ttl    60    MX  10 mail.example.com.; MX with TTL
+        ttl-class   60 IN MX  10 mail.example.com ; MX with TTL and class type
+        class-ttl   IN 60 MX  10 mail.example.com ; MX with class type and TTL
         
         @             AAAA  2001:db8:a::1         ; IPv6, lowercase
         ns            AAAA  2001:DB8:B::1         ; IPv6, uppercase
@@ -160,7 +164,7 @@ RSpec.describe "DNS::Zonefile" do
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(64)
+      expect(zone.rr.size).to eq(68)
     end
 
     it "should build the correct NS records" do
@@ -290,7 +294,7 @@ RSpec.describe "DNS::Zonefile" do
     it "should build the correct MX records" do
       zone = DNS::Zonefile.load(@zonefile)
       mx_records = zone.records_of DNS::Zonefile::MX
-      expect(mx_records.length).to eq(4)
+      expect(mx_records.length).to eq(8)
 
       expect(mx_records.detect { |mx|
         mx.host == "example.com." && mx.priority == 10 && mx.exchanger == "mail.example.com."

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe "DNS::Zonefile" do
         
         with-underscore TXT abc_123
         with-dot  TXT a.b
+        with-dash TXT a-b
 
         with-ttl 60 TXT "example"
         with-class IN TXT "example"
@@ -189,7 +190,7 @@ RSpec.describe "DNS::Zonefile" do
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(93)
+      expect(zone.rr.size).to eq(94)
     end
 
     it "should build the correct NS records" do
@@ -414,7 +415,7 @@ RSpec.describe "DNS::Zonefile" do
     it "should build the correct TXT records" do
       zone = DNS::Zonefile.load(@zonefile)
       txt_records = zone.records_of DNS::Zonefile::TXT
-      expect(txt_records.size).to eq(13)
+      expect(txt_records.size).to eq(14)
 
       expect(txt_records.detect { |r|
         r.host == "_domainkey.example.com." && r.data == '"v=DKIM1\;g=*\;k=rsa\; p=4tkw1bbkfa0ahfjgnbewr2ttkvahvfmfizowl9s4g0h28io76ndow25snl9iumpcv0jwxr2k"'

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -91,6 +91,10 @@ RSpec.describe "DNS::Zonefile" do
         @             CAA   0 issue "letsencrypt.org"
         issuewild     CAA   0 issuewild "comodoca.com"
         iodef         CAA   0 iodef "mailto:example@example.com"
+        with-class IN   CAA 0 issue "letsencrypt.org"
+        with-ttl  60    CAA 0 issue "letsencrypt.org"
+        ttl-class 60 IN CAA 0 issue "letsencrypt.org"
+        class-ttl IN 60 CAA 0 issue "letsencrypt.org"
         
         ; Microsoft AD DNS Examples with Aging.
         with-age [AGE:999992222] 60     A   10.0.0.7             ; with a specified AGE
@@ -156,7 +160,7 @@ RSpec.describe "DNS::Zonefile" do
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(60)
+      expect(zone.rr.size).to eq(64)
     end
 
     it "should build the correct NS records" do
@@ -234,7 +238,7 @@ RSpec.describe "DNS::Zonefile" do
     it "should build the correct CAA records" do
       zone = DNS::Zonefile.load(@zonefile)
       caa_records = zone.records_of DNS::Zonefile::CAA
-      expect(caa_records.size).to eq(3)
+      expect(caa_records.size).to eq(7)
 
       expect(caa_records.detect { |caa|
         caa.host == "example.com." && caa.flags == 0 && caa.tag == "issue" && caa.value == "\"letsencrypt.org\""

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe "DNS::Zonefile" do
         ; Let's start the resource records.
         example.com.  NS    ns                    ; ns.example.com is the nameserver for example.com
         example.com.  NS    ns.somewhere.com.     ; ns.somewhere.com is a backup nameserver for example.com
+        example.com. IN     NS ns.example.net.    ; NS with class
+        example.com. 60     NS ns.example.net.    ; NS with TTL
+        example.com. 60 IN  NS ns.example.net.    ; NS with class and TTL
+        example.com. IN 60  NS ns.example.net.    ; NS with TTL and class
 
         example.com.  A     10.0.0.1              ; ip address for "example.com". next line has spaces after the IP, but no actual comment.
         @             A     10.0.0.11
@@ -168,13 +172,13 @@ RSpec.describe "DNS::Zonefile" do
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(72)
+      expect(zone.rr.size).to eq(76)
     end
 
     it "should build the correct NS records" do
       zone = DNS::Zonefile.load(@zonefile)
       ns_records = zone.records_of DNS::Zonefile::NS
-      expect(ns_records.size).to eq(2)
+      expect(ns_records.size).to eq(6)
 
       expect(ns_records.detect { |ns|
         ns.host == "example.com." && ns.nameserver == "ns.example.com."


### PR DESCRIPTION
Implement support for TTL and class reordering on record types where it was not yet implemented, including: A, AAAA, CAA, MX, NAPTR, NS, PTR, SOA, SPF, SSHFP, and TXT.